### PR TITLE
`@keep` RPCProvider Class

### DIFF
--- a/example/src/main/java/link/magic/DemoApp.kt
+++ b/example/src/main/java/link/magic/DemoApp.kt
@@ -9,7 +9,7 @@ class DemoApp : Application() {
     lateinit var magic: Any
     override fun onCreate() {
 
-        magic = Magic(this, "YOUR_MAGIC_PUBLISHABLE_KEY", ethNetwork = EthNetwork.Goerli)
+        magic = Magic(this, "YOUR_MAGIC_PUBLISHABLE_KEY")
         debugEnabled = true
         super.onCreate()
     }

--- a/magic/core/consumer-rules.pro
+++ b/magic/core/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep public class link.magic.android.core.provider.RpcProvider

--- a/magic/core/gradle.properties
+++ b/magic/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.0.0
+VERSION_NAME=8.0.1
 POM_DESCRIPTION=Magic Android SDK
 POM_NAME=magic-android
 POM_ARTIFACT_ID=magic-android

--- a/magic/core/proguard-rules.pro
+++ b/magic/core/proguard-rules.pro
@@ -23,3 +23,6 @@
 # Add web3j classes here to prevent obfuscation during JSON serialization
 -keep public class org.web3j.protocol.core.Response
 -keep public class org.web3j.protocol.core.Request
+
+# Prevent the instance of the Magic WebView from being garbage collected
+-keep public class link.magic.android.core.provider.RpcProvider

--- a/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
@@ -3,6 +3,7 @@ package link.magic.android.core.provider
 import android.content.Context
 import android.util.Log
 import android.util.Log.DEBUG
+import androidx.annotation.Keep
 import com.google.gson.Gson
 import io.reactivex.Flowable
 import link.magic.android.Magic
@@ -27,6 +28,7 @@ import java.util.concurrent.CompletableFuture
  * @param
  *
  */
+@Keep
 class RpcProvider internal constructor(initialContext: Context, val urlBuilder: URLBuilder) : Web3jService {
 
     /**


### PR DESCRIPTION
Some of our users have found that their apps hang after the app has been left running for some time. `@keep`ing the `RPCProvider` where the WebView is instantiated should remedy this problem. 