### PR TITLE
Adds 5 second interval "Heartbeat" to RpcProvider

### DIFF
--- a/magic/core/gradle.properties
+++ b/magic/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.0.4
+VERSION_NAME=8.0.5
 POM_DESCRIPTION=Magic Android SDK
 POM_NAME=magic-android
 POM_ARTIFACT_ID=magic-android

--- a/magic/core/src/main/java/link/magic/android/core/provider/HeatbeatResponse.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/HeatbeatResponse.kt
@@ -1,0 +1,7 @@
+package link.magic.android.core.provider
+
+import androidx.annotation.Keep
+import org.web3j.protocol.core.Response
+
+@Keep
+class HeartbeatResponse : Response<String>()

--- a/magic/core/src/main/java/link/magic/android/core/provider/Method.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/Method.kt
@@ -1,0 +1,9 @@
+package link.magic.android.core.provider
+
+enum class Method {
+    MAGIC_BOX_HEART_BEAT;
+
+    override fun toString(): String {
+        return name.lowercase()
+    }
+}

--- a/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
@@ -33,8 +33,8 @@ import java.util.concurrent.CompletableFuture
 class RpcProvider internal constructor(initialContext: Context, val urlBuilder: URLBuilder) : Web3jService {
 
     init {
-        // Ping the iFrame every 2min to prevent the WebView from garbage collecting it
-        setInterval(120000) {
+        // Ping the iFrame every 5 seconds to prevent the WebView from garbage collecting it
+        setInterval(5000) {
             val request = Request(Method.MAGIC_BOX_HEART_BEAT.toString(), emptyList<String>(), this,  HeartbeatResponse::class.java)
             sendAsync(request, HeartbeatResponse::class.java)
         }

--- a/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
@@ -5,6 +5,9 @@ import android.util.Log
 import android.util.Log.DEBUG
 import com.google.gson.Gson
 import io.reactivex.Flowable
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import link.magic.android.Magic
 import link.magic.android.core.relayer.WebViewWrapper
 import link.magic.android.core.relayer.message.OutboundMessageType
@@ -29,6 +32,13 @@ import java.util.concurrent.CompletableFuture
  */
 class RpcProvider internal constructor(initialContext: Context, val urlBuilder: URLBuilder) : Web3jService {
 
+    init {
+        // Ping the iFrame every 2min to prevent the WebView from garbage collecting it
+        setInterval(120000) {
+            val request = Request(Method.MAGIC_BOX_HEART_BEAT.toString(), emptyList<String>(), this,  HeartbeatResponse::class.java)
+            sendAsync(request, HeartbeatResponse::class.java)
+        }
+    }
     /**
      * Construct Relayer to send payloads to WebView
      */
@@ -132,5 +142,12 @@ class RpcProvider internal constructor(initialContext: Context, val urlBuilder: 
         throw UnsupportedOperationException(String.format(
                 "Magic-SDK: Service %s does not support Close function",
                 this.javaClass.simpleName))
+    }
+
+    private fun setInterval(timeMillis: Long, handler: () -> Unit) = GlobalScope.launch {
+        while (true) {
+            delay(timeMillis)
+            handler()
+        }
     }
 }


### PR DESCRIPTION
Android's Webview garbage collects memory intensive items like the iFrame when it's no longer being used. This prevents the OS from doing so and creating app hang ups. 