### PR TITLE
Adds `resetContext` Method to WebViewWrapper

### DIFF
--- a/magic/core/gradle.properties
+++ b/magic/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=8.0.8
+VERSION_NAME=8.1.8
 POM_DESCRIPTION=Magic Android SDK
 POM_NAME=magic-android
 POM_ARTIFACT_ID=magic-android

--- a/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
@@ -1,5 +1,6 @@
 package link.magic.android.core.provider
 
+import android.app.Application
 import android.content.Context
 import android.util.Log
 import android.util.Log.DEBUG
@@ -31,7 +32,17 @@ class RpcProvider internal constructor(initialContext: Context, val urlBuilder: 
     /**
      * Construct Relayer to send payloads to WebView
      */
-    internal var overlay = WebViewWrapper(initialContext, urlBuilder)
+    internal var overlay = WebViewWrapper(initialContext, urlBuilder) {
+        // Fallback to Application context when payload resolves in WebViewWrapper to prevent memory leak
+        if (initialContext is Application) {
+            if(Magic.debugEnabled) {
+                Log.i("Magic", "RpcProvider: context reset to application context")
+            }
+            context = initialContext
+        } else {
+            throw IllegalArgumentException("Attempting to reset provider context without application context")
+        }
+    }
 
     /**
      * get and setter Context for UI views to be displayed

--- a/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
+++ b/magic/core/src/main/java/link/magic/android/core/provider/RpcProvider.kt
@@ -50,6 +50,7 @@ class RpcProvider internal constructor(initialContext: Context, val urlBuilder: 
     var context: Context = overlay.mMutableContext.baseContext
     set(newCtx) {
         overlay.setContext(newCtx)
+        // Oauth extension requires access to context here, otherwise we would need to make the WebView public
         field = newCtx
     }
 

--- a/magic/core/src/main/java/link/magic/android/core/relayer/WebViewWrapper.kt
+++ b/magic/core/src/main/java/link/magic/android/core/relayer/WebViewWrapper.kt
@@ -33,7 +33,7 @@ import java.util.*
 /**
  * This class is designed to be instantiate only once. As for the webview
  */
-class WebViewWrapper internal constructor(context: Context, private val urlBuilder: URLBuilder) {
+class WebViewWrapper internal constructor(context: Context, private val urlBuilder: URLBuilder, resetContext: () -> Unit) {
 
     internal val mMutableContext = MutableContextWrapper(context)
     private val mImmutableContext = context
@@ -48,6 +48,8 @@ class WebViewWrapper internal constructor(context: Context, private val urlBuild
     private var missedMessage: String? = null
     private val FIVE_SECONDS = 5_000L
     private val debouncer: Debouncer = Debouncer()
+
+    private val resetContext: () -> Unit = resetContext
 
      init {
          WebView.setWebContentsDebuggingEnabled(true)
@@ -142,6 +144,7 @@ class WebViewWrapper internal constructor(context: Context, private val urlBuild
                 val json = Gson().toJson(response.response)
                 messageHandlers[response.response.id]?.let { it(json) }
                 messageHandlers.remove(response.response.id)
+                resetContext()
             }
             InboundMessageType.MAGIC_MG_BOX_SEND_RECEIPT.toString() in response.msgType -> {
                 // When a receipt is received cancel previously invoked debounce call


### PR DESCRIPTION
- Adds `resetContext` callback method to `WebViewWrapper` to call when payloads resolve, reset context to `ApplicationContext` and prevent potential memory leaks. 