### PR TITLE
fix: use WebViewClient instead of WebViewClientCompat

### DIFF
--- a/magic/core/gradle.properties
+++ b/magic/core/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=10.5.1
+VERSION_NAME=10.6.0
 POM_DESCRIPTION=Magic Android SDK
 POM_NAME=magic-android
 POM_ARTIFACT_ID=magic-android

--- a/magic/core/src/main/java/link/magic/android/core/relayer/MagicWebViewClient.kt
+++ b/magic/core/src/main/java/link/magic/android/core/relayer/MagicWebViewClient.kt
@@ -9,11 +9,8 @@ import android.webkit.URLUtil
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
-import androidx.webkit.WebViewClientCompat
 
-
-internal class MagicWebViewClient : WebViewClientCompat() {
-
+internal class MagicWebViewClient : WebViewClient() {
     // The starting activity call in each if-branch looks the same,
     // keeping this structure just in case, we need tweak according to different deeplink url format
     // in the future


### PR DESCRIPTION
We don't need to use `WebViewClientCompat`, which is known to be more buggy, like [this bug](https://fortmatic.slack.com/archives/CGDJA37L2/p1721054749078419) reported by Mode Mobile.